### PR TITLE
Disable testing deprecated packages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ node_modules/
 
 
 # Temporary workaround before discovery server is removed
-discovery-server/dnetserver/TestPool
+cmd/discovery-server/dnetserver/TestPool

--- a/cmd/discovery-server/dnetserver/discovery_test.go
+++ b/cmd/discovery-server/dnetserver/discovery_test.go
@@ -1,3 +1,5 @@
+// +build deprecated
+
 // +build !integration
 
 package dnetserver

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,3 +1,5 @@
+// +build deprecated
+
 // +build !integration
 
 package logger


### PR DESCRIPTION
These packages will soon be gone. We should just disable the normal
tests so no time is wasted trying to fix them.